### PR TITLE
Add new methods BanPhrases and UnbanPhrases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -49,3 +49,8 @@ Clients may try to bypass a chat filter in place by using characters similar, ye
     //Removes 'https://' to the list of banned phrases (If so added)
     //isClean('https://') would then return true
 
+# Contributing
+
+To contribute to `phrase-blacklist` you first should fork the repository on GitHub and clone it to your local machine.
+
+After making your changes you should first run the existing tests using `npm test` and then add any new relevent tests if appropriate. If you are fixing a bug we recommend you create a test that tests your fix to prevent regressions in the future. 

--- a/index.js
+++ b/index.js
@@ -34,14 +34,29 @@ class WordFilter {
 	BanPhrase(phrase){
 		this.bannedContainment.push(phrase)
 	}
+
+	//Ability to multiple banned phrases
+	//ex. Practical for adding a bunch of phrases you already have in an array
+	BanPhrases(arr){
+		arr.forEach(phrase => {
+			this.BanPhrase(phrase)
+		});
+	}
 	
-	//Ability to unban phrases
+	//Ability to unban an individual phrase
 	UnbanPhrase(phrase){
 		let index = this.bannedContainment.indexOf(phrase)
 		if(index !== -1)
 			this.bannedContainment.splice(index, 1);
 	}
-    
+	
+	//Ability to unban multiple phrases
+	UnbanPhrases(arr){
+		arr.forEach(phrase => {
+			this.UnbanPhrase(phrase)
+		});
+	}
+
 	//Translate a string like c0ck to cock
 	EvasionTranslate(text){
 		//Grab each evasion char replace with possible original char

--- a/package.json
+++ b/package.json
@@ -3,14 +3,24 @@
   "version": "1.1.12",
   "description": "Filter out strings with banned words and bypasses some evasion",
   "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/2JJ1/phrase-blacklist.git"
   },
   "author": "Jonathon Powell",
+  "contributors": [{
+    "name": "Jonathan Fielding",
+    "url" : "https://www.jonathanfielding.com"
+  }],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/2JJ1/phrase-blacklist/issues"
   },
-  "homepage": "https://github.com/2JJ1/phrase-blacklist#readme"
+  "homepage": "https://github.com/2JJ1/phrase-blacklist#readme",
+  "dev-dependencies": {
+    "jest": "^23.6.0"
+  }
 }

--- a/test/phrase-blacklist.test.js
+++ b/test/phrase-blacklist.test.js
@@ -1,0 +1,43 @@
+const phraseBlacklist = require('../index');
+
+test('Check adding a phrase using BanPhrase then removing using UnbanPhrase', () => {
+    const oldPhraseCount = phraseBlacklist.bannedContainment.length;
+    const oldLastItem = phraseBlacklist.bannedContainment[oldPhraseCount - 1];
+
+    phraseBlacklist.BanPhrase('testing');
+
+    expect(phraseBlacklist.bannedContainment.length).toBe(oldPhraseCount + 1);
+    expect(phraseBlacklist.bannedContainment[oldPhraseCount]).toBe('testing');
+
+    phraseBlacklist.UnbanPhrase('testing');
+
+    expect(phraseBlacklist.bannedContainment.length).toBe(oldPhraseCount);
+    expect(phraseBlacklist.bannedContainment[oldPhraseCount - 1]).toBe(oldLastItem);
+});
+
+test('Check adding a phrase using BanPhrases then removing using UnbanPhrases', () => {
+    const oldPhraseCount = phraseBlacklist.bannedContainment.length;
+    const oldLastItem = phraseBlacklist.bannedContainment[oldPhraseCount - 1];
+    const banPhrases = [
+        'test1',
+        'test2',
+        'test3',
+        'test4',
+        'test5',
+    ];
+
+    phraseBlacklist.BanPhrases(banPhrases);
+
+    expect(phraseBlacklist.bannedContainment.length).toBe(oldPhraseCount + 5);
+    expect(phraseBlacklist.bannedContainment[oldPhraseCount]).toBe('test1');
+    expect(phraseBlacklist.bannedContainment[oldPhraseCount + 1]).toBe('test2');
+    expect(phraseBlacklist.bannedContainment[oldPhraseCount + 2]).toBe('test3');
+    expect(phraseBlacklist.bannedContainment[oldPhraseCount + 3]).toBe('test4');
+    expect(phraseBlacklist.bannedContainment[oldPhraseCount + 4]).toBe('test5');
+
+    phraseBlacklist.UnbanPhrases(banPhrases);
+
+    expect(phraseBlacklist.bannedContainment.length).toBe(oldPhraseCount);
+    expect(phraseBlacklist.bannedContainment[oldPhraseCount - 1]).toBe(oldLastItem);
+});
+


### PR DESCRIPTION
This pull request adds the ability to add and remove multiple ban phrases at once. This is useful when you have a long list of phrases to ban, in my use case I am trying to categorise tags I am scrapping from other websites are NSFW or not. 

I also added some unit tests using Jest.